### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "hhennes/module-cms",
     "description": "Add canonical tag to magento 2 cms pages",
     "type": "magento2-module",
-    "version": "1.0.0",
     "license": [
         "AFL-3.0"
     ],


### PR DESCRIPTION
This often leads to issues, see e.g. https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/